### PR TITLE
trap scoring

### DIFF
--- a/src/main/java/frc/robot/commands/IndexCommand.java
+++ b/src/main/java/frc/robot/commands/IndexCommand.java
@@ -104,7 +104,7 @@ public class IndexCommand extends Command {
       runsEmpty = 0;
       intake.intakeOff();
       if(revUpSupplier.getAsBoolean()||stageAngleSup.getAsBoolean()||subwooferAngleSup.getAsBoolean()) {
-        if(angleShooterSubsytem.shortSpeakerDist()) {
+        if(angleShooterSubsytem.shortSpeakerDist()||subwooferAngleSup.getAsBoolean()) {
           shooter.shootRPS(ShooterConstants.SHORT_SHOOTING_RPS);
         } else {
           shooter.shootRPS(ShooterConstants.LONG_SHOOTING_RPS);


### PR DESCRIPTION
now we can score on trap with the same settings as for the subwoofer. the one change was to force us to use our close-up shooting speed if we are aiming at the subwoofer.